### PR TITLE
Upgrade zotero to 5.0.89

### DIFF
--- a/zotero/zotero.spec
+++ b/zotero/zotero.spec
@@ -1,7 +1,7 @@
 %define debug_package %{nil}
 
 Name:		  zotero
-Version:	5.0.88
+Version:	5.0.89
 Release:	1%{?dist}
 Summary:	Collect, organize, cite, and share research sources
 
@@ -39,6 +39,8 @@ install -Dm644 %{buildroot}/%{_libdir}/%{name}/chrome/icons/default/default256.p
 
 
 %changelog
+* Fri Aug 14 2020 Bugzy Little <bugzylittle@gmail.com> - 5.0.89-1
+- Upgrade to 5.0.89
 * Thu Jun 25 2020 Bugzy Little <bugzylittle@gmail.com> - 5.0.88-1
 - Upgrade to 5.0.88
 * Mon Aug 05 2019 Grace Petegorsky <grace.petegorsky@yale.edu> - 5.0.73-1


### PR DESCRIPTION
Changes in 5.0.89 (July 22, 2020)
* Restored detection of some instances of database corruption at Zotero startup (since 5.0.88)
* Ignore leading commas in citation dialog search
* Fixed error trying to update bibliography in word processor document when no citations are present
* Fixed error updating Word document when using AutoMark and index entries are created within Zotero citations
* Miscellaneous bibliographic output and word processor integration fixes
  * Updated citeproc-js to version 1.4.11
* Fixed detection of retractions for items with DOI in Extra field
* Fixed unnecessary style updating at startup in timezones > UTC

